### PR TITLE
Fixing second typo.

### DIFF
--- a/fenestrate.js
+++ b/fenestrate.js
@@ -179,7 +179,7 @@ var commands = {
   activate: function(modPath, prod) {
     shunt(modPath, false, prod);
   },
-  deactivate: function(modpath, prod) {
+  deactivate: function(modPath, prod) {
     shunt(modPath, true, prod);
   },
   rewrite: function(modPath, restore, prod) {


### PR DESCRIPTION
Sorry, meant to include this in the previous pull request.  The case difference was causing undefined to be passed to shunt, causing deactivate not to work.  With activate and deactivate both up and running, this utility is working great for our project.  Thanks!