### PR TITLE
Use larger stdout buffer to cope with large node_modules trees

### DIFF
--- a/fenestrate.js
+++ b/fenestrate.js
@@ -148,7 +148,7 @@ var commands = {
     }
 
     log('Reading installed dependencies for ' + modPath);
-    childProcess.exec("npm ls --json", { cwd: modPath }, function(err, res) {
+    childProcess.exec("npm ls --json", { maxBuffer: 1024 * 4096, cwd: modPath }, function(err, res) {
       if (err && !res) {
         console.error("Failed to do initial listing of dependencies.");
         die(err.message);


### PR DESCRIPTION
I ran into an issue where using `fenestrate` to flatten a large node_modules tree ran into the default 200KB stdout buffer limit. This increases that limit to 4MB to get around this issue.
